### PR TITLE
Fix scripts path for TestPrepApplication

### DIFF
--- a/DotNetDaterbaser.TestPrepApplication/Program.cs
+++ b/DotNetDaterbaser.TestPrepApplication/Program.cs
@@ -24,7 +24,7 @@ namespace DotNetDaterbaser.TestPrepApplication
                 await DropTablesAsync(cs).ConfigureAwait(false);
             }
 
-            var scriptsDir = Path.Combine(AppContext.BaseDirectory, "..", "DotNetDaterbaser.TestApplication", "Scripts");
+            var scriptsDir = Path.Combine(Environment.CurrentDirectory, "Scripts");
             var prefix = "localhost_DotNetDaterbaserGamma_";
             var full = Path.Combine(scriptsDir, $"{prefix}full_database_script.sql");
             var partials = Directory.GetFiles(scriptsDir, $"{prefix}*_script.sql")


### PR DESCRIPTION
## Summary
- resolve incorrect path to SQL scripts in TestPrepApplication

## Testing
- `dotnet restore`
- `dotnet build --configuration Release --no-restore` *(fails: dotnet run --project ../DotNetDaterbaser.TestPrepApplication exited with code 134)*

------
https://chatgpt.com/codex/tasks/task_e_6881455da73083239a468ed50964def9