### PR TITLE
Fix initial full script execution

### DIFF
--- a/DotNetDaterbaser/Program.cs
+++ b/DotNetDaterbaser/Program.cs
@@ -107,10 +107,15 @@ namespace DotNetDaterbaser
                 {
                     await RunSqlScriptAsync(conn, await File.ReadAllTextAsync(fullFile));
                     entry.FullRun = true;
+
                     foreach (var p in partials)
                     {
-                        entry.Scripts.Add(Path.GetFileName(p));
+                        await RunSqlScriptAsync(conn, await File.ReadAllTextAsync(p));
+                        var name = Path.GetFileName(p);
+                        entry.Scripts.Add(name);
+                        await File.AppendAllTextAsync(logFile, $"Ran script {name}{Environment.NewLine}");
                     }
+
                     await File.AppendAllTextAsync(logFile, $"Ran full script {Path.GetFileName(fullFile)}{Environment.NewLine}");
                 }
                 else


### PR DESCRIPTION
## Summary
- run partial scripts during initial full script execution

## Testing
- `dotnet restore`
- `dotnet build --configuration Release --no-restore` *(fails: docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_6881482a8e9083239a683dab8304cb79