### PR TITLE
Fix initial full script execution

### DIFF
--- a/DotNetDaterbaser/Program.cs
+++ b/DotNetDaterbaser/Program.cs
@@ -102,29 +102,23 @@ namespace DotNetDaterbaser
 
                 var logFile = Path.Combine(outputDir, $"{key}.log");
 
-                // Run the full database script once before applying partial scripts
+                // Execute the full script if it has not yet been run
                 if (!entry.FullRun && File.Exists(fullFile))
                 {
                     await RunSqlScriptAsync(conn, await File.ReadAllTextAsync(fullFile));
                     entry.FullRun = true;
-                    foreach (var p in partials)
-                    {
-                        entry.Scripts.Add(Path.GetFileName(p));
-                    }
                     await File.AppendAllTextAsync(logFile, $"Ran full script {Path.GetFileName(fullFile)}{Environment.NewLine}");
                 }
-                else
+
+                // Execute any new partial scripts
+                foreach (var p in partials)
                 {
-                    // Execute any new partial scripts
-                    foreach (var p in partials)
+                    var name = Path.GetFileName(p);
+                    if (!entry.Scripts.Contains(name))
                     {
-                        var name = Path.GetFileName(p);
-                        if (!entry.Scripts.Contains(name))
-                        {
-                            await RunSqlScriptAsync(conn, await File.ReadAllTextAsync(p));
-                            entry.Scripts.Add(name);
-                            await File.AppendAllTextAsync(logFile, $"Ran script {name}{Environment.NewLine}");
-                        }
+                        await RunSqlScriptAsync(conn, await File.ReadAllTextAsync(p));
+                        entry.Scripts.Add(name);
+                        await File.AppendAllTextAsync(logFile, $"Ran script {name}{Environment.NewLine}");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- run partial scripts after verifying full script status
- track scripts only once

## Testing
- `dotnet restore`
- `dotnet build --configuration Release --no-restore` *(fails: could not connect to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_6881482a8e9083239a683dab8304cb79