### PR TITLE
Fix prep script tracking

### DIFF
--- a/DotNetDaterbaser.TestPrepApplication/TrackingEntry.cs
+++ b/DotNetDaterbaser.TestPrepApplication/TrackingEntry.cs
@@ -1,0 +1,18 @@
+namespace DotNetDaterbaser.TestPrepApplication
+{
+    /// <summary>
+    /// Tracks executed scripts for the prep application.
+    /// </summary>
+    public class TrackingEntry
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the full database script has run.
+        /// </summary>
+        public bool FullRun { get; set; }
+
+        /// <summary>
+        /// Gets the set of individual script names that have executed.
+        /// </summary>
+        public HashSet<string> Scripts { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- update TestPrepApplication to record executed scripts in tracking.json

## Testing
- `dotnet restore`
- `dotnet build DotNetDaterbaser/DotNetDaterbaser.csproj --configuration Release --no-restore`
- `dotnet build DotNetDaterbaser.TestPrepApplication/DotNetDaterbaser.TestPrepApplication.csproj --configuration Release --no-restore`
- `dotnet format --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68814cd7e26c8323a6c444e427652edc