### PR TITLE
Remove namespace naming recommendation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,6 @@ public class UserService
 - All code must be declared within a logically grouped namespace.
 - Namespace names should match the folder structure.
 - Use the block-scoped namespace declaration introduced in C# 10+.
-- Namespace names should follow the format: `Company.Product.Module`.
-
 Example:
 ```csharp
 namespace MyCompany.MyApp.Services


### PR DESCRIPTION
## Summary
- remove the `Company.Product.Module` guideline from `AGENTS.md`

## Testing
- `dotnet restore`
- `dotnet build` *(failed: TestApplication run error)*
- `dotnet build DotNetDaterbaser/DotNetDaterbaser.csproj --configuration Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68877d94cafc83238a1335c9179abc91